### PR TITLE
ci(renovate): sign off Renovate commits to satisfy DCO

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -6,6 +6,7 @@
     ":semanticCommits"
   ],
   "labels": ["dependencies"],
+  "commitBody": "Signed-off-by: Ronny Trommer <ronny@no42.org>",
   "packageRules": [
     {
       "description": "Pin GitHub Actions to an immutable SHA (keep the semver comment)",


### PR DESCRIPTION
Renovate's commits are authored under the maintainer identity but lacked
a Signed-off-by trailer, so the DCO check failed on every dependency PR.
Set commitBody so all future Renovate commits carry the sign-off.

Assisted-by: ClaudeCode:claude-opus-4-8
Signed-off-by: Ronny Trommer <ronny@no42.org>
