### PR TITLE
chore(deps): update ubuntu docker tag to noble-20260610

### DIFF
--- a/base_images.sh
+++ b/base_images.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # Base images as dependencies
-export OS_UBUNTU="ubuntu:noble-20250714"
+export OS_UBUNTU="ubuntu:noble-20260610"
 export OS_ALPINE="alpine:3.24"
 export OS_DEBIAN="debian:bookworm-20250203-slim"
 export APP_ANTORA="antora/antora:3.1.15"


### PR DESCRIPTION
Advances the Ubuntu base within the 24.04 (noble) line. The 26.04 major
was closed because fd.io ships no VPP packages for 26.04 (breaks the vpp
image) and CMake 4.x breaks udpgen there; this patch keeps those working.

Assisted-by: ClaudeCode:claude-opus-4-8
Signed-off-by: Ronny Trommer <ronny@no42.org>
