### PR TITLE
ci(renovate): stop bumping grpcio/grpcio-tools/protobuf independently

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -12,6 +12,12 @@
       "description": "Pin GitHub Actions to an immutable SHA (keep the semver comment)",
       "matchManagers": ["github-actions"],
       "pinDigests": true
+    },
+    {
+      "description": "grpcio, grpcio-tools and protobuf are hard-pinned by robotframework-browser (e.g. grpcio==1.81.0, protobuf==6.33.6). Let it drive their versions instead of proposing independent bumps that cannot resolve.",
+      "matchFileNames": ["robotframework/requirements.txt"],
+      "matchPackageNames": ["grpcio", "grpcio-tools", "protobuf"],
+      "enabled": false
     }
   ],
   "customManagers": [


### PR DESCRIPTION
robotframework-browser 20.0.0 hard-pins grpcio==1.81.0, grpcio-tools==
1.81.0 and protobuf==6.33.6, so Renovate's independent 'latest' proposals
for these (grpcio 1.82, protobuf 7) can never resolve and just churn as
failing PRs. Disable independent updates and let robotframework-browser
drive their versions.

Assisted-by: ClaudeCode:claude-opus-4-8
Signed-off-by: Ronny Trommer <ronny@no42.org>
