### PR TITLE
feat: multi-arch (amd64+arm64) publishing to quay.io signed with cosign

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -96,15 +96,19 @@ jobs:
     needs: discover
     if: needs.discover.outputs.any == 'true'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write   # keyless cosign signing via GitHub OIDC
     strategy:
       fail-fast: false
       matrix:
         project: ${{ fromJSON(needs.discover.outputs.projects) }}
     env:
-      CONTAINER_REGISTRY: ${{ secrets.CONTAINER_REGISTRY }}
-      CONTAINER_REGISTRY_REPO: ${{ secrets.CONTAINER_REGISTRY_REPO }}
-      CONTAINER_REGISTRY_LOGIN: ${{ secrets.CONTAINER_REGISTRY_LOGIN }}
-      CONTAINER_REGISTRY_PASS: ${{ secrets.CONTAINER_REGISTRY_PASS }}
+      # Registry host is a literal; org + robot credentials come from secrets.
+      CONTAINER_REGISTRY: quay.io
+      CONTAINER_REGISTRY_REPO: ${{ secrets.QUAY_LABMONKEYS_ORG }}
+      CONTAINER_REGISTRY_LOGIN: ${{ secrets.QUAY_USERNAME }}
+      CONTAINER_REGISTRY_PASS: ${{ secrets.QUAY_PASSWORD }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
@@ -114,15 +118,22 @@ jobs:
           sudo curl -fsSL -o /usr/local/bin/hadolint \
             https://github.com/hadolint/hadolint/releases/download/v2.12.0/hadolint-Linux-x86_64
           sudo chmod +x /usr/local/bin/hadolint
-      - name: Build (branch/PR) or publish (main)
+      - name: Set up QEMU (multi-arch emulation)
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8  # v4.2.0
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c  # v4.2.0
+      - name: Install cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6  # v4.1.2
+      - name: Build (branch/PR) or publish + sign (main)
         working-directory: ./${{ matrix.project }}
         run: |
           set -euo pipefail
           if [[ "${{ github.event_name }}" == "push" && "${{ github.ref }}" == "refs/heads/main" && -n "${CONTAINER_REGISTRY_LOGIN}" ]]; then
             make publish BUILD_VERSION_SUFFIX=".b${{ github.run_number }}"
+            make sign    BUILD_VERSION_SUFFIX=".b${{ github.run_number }}"
           else
             if [[ "${{ github.event_name }}" == "push" && "${{ github.ref }}" == "refs/heads/main" ]]; then
-              echo "::notice::CONTAINER_REGISTRY_* secrets not configured — building image only, skipping publish."
+              echo "::notice::QUAY_* secrets not configured — building image only, skipping publish and signing."
             fi
             make oci
           fi

--- a/README.md
+++ b/README.md
@@ -84,11 +84,43 @@ a `Dockerfile.tpl`, so Renovate can keep them current.
   shared file (`base_images.sh`, `include.mk`, root `Makefile`, or the workflow)
   rebuilds every project.
 - **build** — a matrix over the changed projects. Pull requests run `make oci`
-  (build only); pushes to `main` run `make publish` with a `.b<run-number>`
-  suffix.
+  (build only); pushes to `main` run `make publish` (multi-arch, per the
+  project's `PLATFORMS`) followed by `make sign`, with a `.b<run-number>` suffix.
 
-Registry credentials are provided as repository secrets: `CONTAINER_REGISTRY`,
-`CONTAINER_REGISTRY_REPO`, `CONTAINER_REGISTRY_LOGIN`, `CONTAINER_REGISTRY_PASS`.
+Registry credentials are provided as repository secrets: `QUAY_USERNAME`,
+`QUAY_PASSWORD`, and `QUAY_LABMONKEYS_ORG` (the registry host `quay.io` is a
+literal in the workflow). The build job requests `id-token: write` so cosign can
+sign keylessly via GitHub OIDC.
+
+## Multi-architecture builds
+
+Each project declares the platforms it supports via `PLATFORMS` in its
+`version-lock.sh` (default `linux/amd64`):
+
+```sh
+export PLATFORMS="linux/amd64,linux/arm64"
+```
+
+`make publish` builds and pushes exactly those platforms as a single
+multi-architecture image index. Images that hardcode an `amd64` artifact select
+the right asset from the Docker build arg `$TARGETARCH`; only the variables
+`version-lock.sh` exports are substituted at render time, so `$TARGETARCH`
+survives into the generated `Dockerfile`.
+
+## Image signatures
+
+Published images are signed with [cosign](https://docs.sigstore.dev/) using
+keyless signing (no stored key) — the signer identity is the GitHub Actions
+workflow. Verify a published image with:
+
+```bash
+cosign verify \
+  --certificate-oidc-issuer=https://token.actions.githubusercontent.com \
+  --certificate-identity-regexp='^https://github.com/labmonkeys-space/app-container/' \
+  quay.io/labmonkeys/<project>:<tag>
+```
+
+A single signature over the image index covers all its architectures.
 
 ## Dependency updates
 

--- a/activemq/version-lock.sh
+++ b/activemq/version-lock.sh
@@ -13,3 +13,6 @@ export BASE_IMAGE="${LANG_JRE_17}"
 export ACTIVEMQ_VERSION="6.1.3"
 export SHA512_VAL="e47e907a85a9625e3e19ccea1bab293eba842e58d30b12936087ececbb65a14297d527152ad276f6f759ad403ad91308671eec66db06ada4d331f903762cc0b4"
 export ACTIVEMQ_HOME="/opt/activemq"
+
+# amd64-only until the quay.io/labmonkeys/openjdk base image is rebuilt multi-arch
+export PLATFORMS="linux/amd64"

--- a/antora/version-lock.sh
+++ b/antora/version-lock.sh
@@ -15,3 +15,5 @@ export MAKE_VERSION="4.4.1-r1"
 export GIT_VERSION="2.40.3-r0"
 export OPENSSH_CLIENT_VERSION="9.3_p2-r2"
 export LUNR_EXTENSION_VERSION="1.0.0-alpha.8"
+
+export PLATFORMS="linux/amd64,linux/arm64"

--- a/cerebro/version-lock.sh
+++ b/cerebro/version-lock.sh
@@ -12,3 +12,6 @@ export DATE
 export BASE_IMAGE="${LANG_JRE_11}"
 export CEREBRO_VERSION="0.9.4"
 export CEREBRO_HOME="/opt/cerebro"
+
+# amd64-only until the quay.io/labmonkeys/openjdk base image is rebuilt multi-arch
+export PLATFORMS="linux/amd64"

--- a/coolmodfiles/version-lock.sh
+++ b/coolmodfiles/version-lock.sh
@@ -11,3 +11,5 @@ export VCS_REVISION
 export DATE
 export BASE_IMAGE="${LANG_NODE_16}"
 export GIT_COMMIT="3f85684c233df6b51407d3feb4885770ff70fc87"
+
+export PLATFORMS="linux/amd64,linux/arm64"

--- a/diag/Dockerfile.tpl
+++ b/diag/Dockerfile.tpl
@@ -4,10 +4,7 @@
 
 FROM "${BASE_IMAGE}"
 
-ADD https://github.com/krallin/tini/releases/download/v0.19.0/tini-amd64 /bin/tini
-ADD https://bin.equinox.io/c/bNyj1mQVY4c/ngrok-v3-stable-linux-amd64.tgz /tmp/ngrok.tgz
-ADD https://github.com/prometheus-community/pro-bing/releases/download/v0.3.0/ping_0.3.0_linux_amd64.tar.gz /tmp/ping.tar.gz
-ADD https://github.com/openconfig/gnmic/releases/download/v${GNMIC_VERSION}/gnmic_${GNMIC_VERSION}_Linux_x86_64.tar.gz /tmp/gnmic.tar.gz
+ARG TARGETARCH
 
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -59,6 +56,15 @@ RUN apt-get update && apt-get -y install --no-install-recommends ca-certificates
     zsh && \
     rm -rf /var/lib/apt/lists/* && \
     echo "${DEBIAN_FRONTEND}" && \
+    case "$TARGETARCH" in \
+      amd64) TINIARCH=amd64; NGROKARCH=amd64; PINGARCH=amd64; GNMICARCH=x86_64 ;; \
+      arm64) TINIARCH=arm64; NGROKARCH=arm64; PINGARCH=arm64; GNMICARCH=aarch64 ;; \
+      *) echo "unsupported TARGETARCH=$TARGETARCH" >&2; exit 1 ;; \
+    esac && \
+    curl -fsSLo /bin/tini "https://github.com/krallin/tini/releases/download/v0.19.0/tini-${TINIARCH}" && \
+    curl -fsSLo /tmp/ngrok.tgz "https://bin.equinox.io/c/bNyj1mQVY4c/ngrok-v3-stable-linux-${NGROKARCH}.tgz" && \
+    curl -fsSLo /tmp/ping.tar.gz "https://github.com/prometheus-community/pro-bing/releases/download/v0.3.0/ping_0.3.0_linux_${PINGARCH}.tar.gz" && \
+    curl -fsSLo /tmp/gnmic.tar.gz "https://github.com/openconfig/gnmic/releases/download/v${GNMIC_VERSION}/gnmic_${GNMIC_VERSION}_Linux_${GNMICARCH}.tar.gz" && \
     tar xzf /tmp/ping.tar.gz -C /tmp --strip-components=1 && \
     mv /tmp/ping /usr/bin/gping && \
     tar xzf /tmp/ngrok.tgz -C /usr/bin && \

--- a/diag/version-lock.sh
+++ b/diag/version-lock.sh
@@ -8,3 +8,5 @@ export VCS_REVISION="$(git describe --always)"
 export BASE_IMAGE="${OS_UBUNTU}"
 export CA_CERT_VERSION="20240203"
 export GNMIC_VERSION="0.46.0"
+
+export PLATFORMS="linux/amd64,linux/arm64"

--- a/dupligator/version-lock.sh
+++ b/dupligator/version-lock.sh
@@ -12,3 +12,5 @@ export DATE
 export BASE_IMAGE="${OS_ALPINE}"
 export BUILDER_IMAGE="${LANG_GO_ALPINE}"
 export GIT_COMMIT="6721d9941eb2674aef14249e2fc6dcecbfe46163"
+
+export PLATFORMS="linux/amd64,linux/arm64"

--- a/featmap/version-lock.sh
+++ b/featmap/version-lock.sh
@@ -11,3 +11,6 @@ export VCS_REVISION
 export DATE
 export BASE_IMAGE="${OS_UBUNTU}"
 export FEATMAP_VERSION="2.1.0"
+
+# amd64-only: upstream ships no arm64 release binary
+export PLATFORMS="linux/amd64"

--- a/freeradius/version-lock.sh
+++ b/freeradius/version-lock.sh
@@ -13,3 +13,5 @@ export BASE_IMAGE="${OS_ALPINE}"
 export FREERADIUS_VERSION="3.0.26-r8"
 export SQLITE_VERSION="3.45.3-r1"
 export OPENSSL_VERSION="3.3.2-r0"
+
+export PLATFORMS="linux/amd64,linux/arm64"

--- a/frrouting/Dockerfile.tpl
+++ b/frrouting/Dockerfile.tpl
@@ -5,6 +5,8 @@
 # hadolint ignore=DL3006
 FROM "${BASE_IMAGE}"
 
+ARG TARGETARCH
+
 RUN apt-get update && \
     apt-get -y install curl \
                        dnsutils \
@@ -32,12 +34,18 @@ RUN apt-get update && \
     mkdir -p /etc/snmp/conf.d && \
     chown -R frr:frr /etc/frr /var/run/frr
 
-# Using s6 to run lldpd and snmpd in the container
+# Using s6 to run lldpd and snmpd in the container. The arch tarball is named
+# x86_64 / aarch64, mapped from TARGETARCH; noarch is architecture-independent.
 ADD https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-noarch.tar.xz /tmp
-ADD https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-x86_64.tar.xz /tmp
 
-RUN tar -C / -Jxpf /tmp/s6-overlay-noarch.tar.xz && \
-    tar -C / -Jxpf /tmp/s6-overlay-x86_64.tar.xz
+RUN case "$TARGETARCH" in \
+      amd64) S6ARCH=x86_64 ;; \
+      arm64) S6ARCH=aarch64 ;; \
+      *) echo "unsupported TARGETARCH=$TARGETARCH" >&2; exit 1 ;; \
+    esac && \
+    curl -fsSLo /tmp/s6-overlay-arch.tar.xz "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-${S6ARCH}.tar.xz" && \
+    tar -C / -Jxpf /tmp/s6-overlay-noarch.tar.xz && \
+    tar -C / -Jxpf /tmp/s6-overlay-arch.tar.xz
 
 # Add a basic configuration for lldpd, snmpd and pmacctd to the container
 COPY config/s6/services /etc/services.d

--- a/frrouting/version-lock.sh
+++ b/frrouting/version-lock.sh
@@ -12,3 +12,5 @@ export DATE
 export BASE_IMAGE="${OS_DEBIAN}"
 export S6_OVERLAY_VERSION="3.2.0.2"
 export FRR_VERSION="10.2.1-0~deb12u1"
+
+export PLATFORMS="linux/amd64,linux/arm64"

--- a/git/version-lock.sh
+++ b/git/version-lock.sh
@@ -13,3 +13,5 @@ export BASE_IMAGE="${OS_ALPINE}"
 export BASH_VERSION="5.2.26-r0"
 export GIT_VERSION="2.45.2-r0"
 export GITHUB_CLI_VERSION="2.47.0-r4"
+
+export PLATFORMS="linux/amd64,linux/arm64"

--- a/gobetween/version-lock.sh
+++ b/gobetween/version-lock.sh
@@ -11,3 +11,6 @@ export VCS_REVISION
 export DATE
 export BASE_IMAGE="${OS_ALPINE}"
 export GOBETWEEN_VERSION="0.8.0"
+
+# amd64-only: upstream ships no arm64 release binary
+export PLATFORMS="linux/amd64"

--- a/gobgp/Dockerfile.tpl
+++ b/gobgp/Dockerfile.tpl
@@ -5,7 +5,9 @@
 # hadolint ignore=DL3006
 FROM "${BASE_IMAGE}"
 
-ADD "https://github.com/osrg/gobgp/releases/download/v${GOBGP_VERSION}/gobgp_${GOBGP_VERSION}_linux_amd64.tar.gz" /tmp/gobgp.tar.gz
+ARG TARGETARCH
+# gobgp release assets are named linux_amd64 / linux_arm64, matching TARGETARCH.
+ADD "https://github.com/osrg/gobgp/releases/download/v${GOBGP_VERSION}/gobgp_${GOBGP_VERSION}_linux_${TARGETARCH}.tar.gz" /tmp/gobgp.tar.gz
 
 RUN tar xzf /tmp/gobgp.tar.gz -C /usr/bin && \
     rm -rf /tmp/gobgp.tar.gz && \

--- a/gobgp/version-lock.sh
+++ b/gobgp/version-lock.sh
@@ -11,3 +11,5 @@ export VCS_REVISION
 export DATE
 export BASE_IMAGE="alpine:3.23.0"
 export GOBGP_VERSION="4.1.0"
+
+export PLATFORMS="linux/amd64,linux/arm64"

--- a/gohugo/Dockerfile.tpl
+++ b/gohugo/Dockerfile.tpl
@@ -5,7 +5,9 @@
 # hadolint ignore=DL3006
 FROM "${BASE_IMAGE}"
 
-ADD "https://github.com/gohugoio/hugo/releases/download/v${GOHUGO_VERSION}/hugo_${GOHUGO_VERSION}_linux-amd64.tar.gz" /tmp/gohugo.tar.gz
+ARG TARGETARCH
+# hugo release assets are named linux-amd64 / linux-arm64, matching TARGETARCH.
+ADD "https://github.com/gohugoio/hugo/releases/download/v${GOHUGO_VERSION}/hugo_${GOHUGO_VERSION}_linux-${TARGETARCH}.tar.gz" /tmp/gohugo.tar.gz
 
 RUN tar xzf /tmp/gohugo.tar.gz -C /usr/bin && \
     rm -rf /tmp/gohugo.tar.gz && \

--- a/gohugo/version-lock.sh
+++ b/gohugo/version-lock.sh
@@ -15,3 +15,5 @@ export RUBY_VERSION="3.3.3-r0"
 export ASCIIDOCTOR_VERSION="2.0.23"
 export NPM_VERSION="10.8.0-r0"
 
+
+export PLATFORMS="linux/amd64,linux/arm64"

--- a/include.mk
+++ b/include.mk
@@ -1,7 +1,7 @@
 ###
 # Makefile to build and release Docker images used in our CI/CD build pipeline and deployments
 ###
-.PHONY: help deps info shellcheck hadolint builder-instance oci login scan publish publish-force clean
+.PHONY: help deps info shellcheck hadolint builder-instance oci login scan publish publish-force sign clean
 
 .DEFAULT_GOAL := oci
 
@@ -14,7 +14,10 @@ CONTAINER_REGISTRY_PASS  ?=
 BUILD_VERSION_SUFFIX     ?=
 RELEASE_TAG              ?= $(shell cat release.tag)$(BUILD_VERSION_SUFFIX)
 SINGLE_ARCH              ?= linux/amd64
-MULTI_ARCH               ?= linux/amd64
+# Platforms this project supports, declared as PLATFORMS in its version-lock.sh.
+# Defaults to linux/amd64 when the project does not declare it.
+PLATFORMS                ?= $(shell bash -c '. ./version-lock.sh >/dev/null 2>&1; printf "%s" "$${PLATFORMS:-linux/amd64}"')
+MULTI_ARCH               ?= $(PLATFORMS)
 BUILDER_INSTANCE         ?= builder-$(PROJECT_DIR)
 DOCKER_TAG               := $(CONTAINER_REGISTRY)/$(CONTAINER_REGISTRY_REPO)/$(RELEASE_TAG)
 
@@ -65,6 +68,7 @@ info: deps
 	@echo ""
 	@docker --version
 	@echo "Image Tag: $(DOCKER_TAG)"
+	@echo "Platforms: $(MULTI_ARCH)"
 	@echo ""
 
 shellcheck: deps
@@ -74,7 +78,10 @@ shellcheck: deps
 
 Dockerfile: shellcheck info
 	@echo -n "Generating Dockerfile: "
-	@source ./version-lock.sh && envsubst < "Dockerfile.tpl" > "Dockerfile"
+	@# Only substitute the variables version-lock.sh / base_images.sh export, so
+	@# Docker build args like $$TARGETARCH (and the image's own $$PATH) survive.
+	@allow="$$(sed -nE 's/^[[:space:]]*export[[:space:]]+([A-Za-z_][A-Za-z0-9_]*).*/$$\1/p' version-lock.sh ../base_images.sh | sort -u | tr '\n' ' ')"; \
+	 source ./version-lock.sh && envsubst "$$allow" < "Dockerfile.tpl" > "Dockerfile"
 	@echo -e "\033[0;32mDONE\033[0m"
 
 hadolint: Dockerfile
@@ -113,6 +120,14 @@ publish-force: info Dockerfile builder-instance login
 	@echo ""
 	@echo -n "Are you sure? [y/N] " && read ans && [ $${ans:-N} == y ]
 	docker buildx build -o type=registry --platform="$(MULTI_ARCH)" --tag "$(DOCKER_TAG)" .
+
+sign: login
+	@command -v cosign >/dev/null || { echo -e "\033[0;31mFAIL\033[0m - cosign not found."; exit 1; }
+	@echo -n "Sign $(DOCKER_TAG) with cosign (keyless): "
+	@tag="$(DOCKER_TAG)"; \
+	 digest="$$(docker buildx imagetools inspect "$$tag" --format '{{.Manifest.Digest}}')"; \
+	 cosign sign --yes "$${tag%:*}@$${digest}"
+	@echo -e "\033[0;32mDONE\033[0m"
 
 clean: deps
 	@echo -n "Remove generated Dockerfile: "

--- a/karaf/version-lock.sh
+++ b/karaf/version-lock.sh
@@ -12,3 +12,6 @@ export DATE
 export KARAF_HOME="/opt/karaf"
 export BASE_IMAGE="${LANG_JRE_17}"
 export KARAF_VERSION="4.4.6"
+
+# amd64-only until the quay.io/labmonkeys/openjdk base image is rebuilt multi-arch
+export PLATFORMS="linux/amd64"

--- a/lldpd/version-lock.sh
+++ b/lldpd/version-lock.sh
@@ -13,3 +13,5 @@ export BASE_IMAGE="${OS_ALPINE}"
 export BASH_VERSION="5.2.26-r0"
 export NETSNMP_VERSION="5.9.4-r0"
 export LLDPD_VERSION="1.0.18-r0"
+
+export PLATFORMS="linux/amd64,linux/arm64"

--- a/mail-lab/Dockerfile.tpl
+++ b/mail-lab/Dockerfile.tpl
@@ -5,6 +5,8 @@
 # hadolint ignore=DL3006
 FROM "${BASE_IMAGE}"
 
+ARG TARGETARCH
+
 # Change default shell for RUN from Dash to Bash
 SHELL ["/bin/bash", "-exo", "pipefail", "-c"]
 
@@ -14,16 +16,22 @@ ENV DEBIAN_FRONTEND=noninteractive
 ENV MAILDOMAIN="example.org"
 ENV MESSAGE_SIZE_LIMIT="52428800"
 
-ADD https://github.com/just-containers/s6-overlay/releases/download/${S6_OVERLAY_VERSION}/s6-overlay-x86_64.tar.xz /tmp/
-
 # hadolint ignore=DL3008
 RUN apt-get update && \
     apt-get -y install --no-install-recommends xz-utils \
+                                               ca-certificates \
+                                               curl \
                                                inetutils-syslogd \
                                                postfix \
                                                dovecot-imapd \
                                                whois && \
-    tar -xf /tmp/s6-overlay-x86_64.tar.xz -C / && \
+    case "$TARGETARCH" in \
+      amd64) S6ARCH=x86_64 ;; \
+      arm64) S6ARCH=aarch64 ;; \
+      *) echo "unsupported TARGETARCH=$TARGETARCH" >&2; exit 1 ;; \
+    esac && \
+    curl -fsSLo /tmp/s6-overlay.tar.xz "https://github.com/just-containers/s6-overlay/releases/download/${S6_OVERLAY_VERSION}/s6-overlay-${S6ARCH}.tar.xz" && \
+    tar -xf /tmp/s6-overlay.tar.xz -C / && \
     rm -rf /var/lib/apt/lists/* && \
     rm /tmp/*.tar.xz
 

--- a/mail-lab/version-lock.sh
+++ b/mail-lab/version-lock.sh
@@ -15,3 +15,5 @@ export INETUTILS_SYSLOGD_VERSION="2:2.5-3ubuntu4"
 export DOVECOT_IMAPD_VERSION="1:2.3.21+dfsg1-2ubuntu6"
 export POSTFIX_VERSION="3.8.6-1build2"
 export WHOIS_VERSION="5.5.22"
+
+export PLATFORMS="linux/amd64,linux/arm64"

--- a/maven-11-jdk/version-lock.sh
+++ b/maven-11-jdk/version-lock.sh
@@ -11,3 +11,6 @@ export VCS_REVISION
 export DATE
 export BASE_IMAGE="${LANG_JDK_11}"
 export MAVEN_VERSION="3.8.7-2"
+
+# amd64-only until the quay.io/labmonkeys/openjdk base image is rebuilt multi-arch
+export PLATFORMS="linux/amd64"

--- a/maven-17-jdk/version-lock.sh
+++ b/maven-17-jdk/version-lock.sh
@@ -11,3 +11,6 @@ export VCS_REVISION
 export DATE
 export BASE_IMAGE="${LANG_JDK_17}"
 export MAVEN_VERSION="3.8.7-2"
+
+# amd64-only until the quay.io/labmonkeys/openjdk base image is rebuilt multi-arch
+export PLATFORMS="linux/amd64"

--- a/net-snmp/version-lock.sh
+++ b/net-snmp/version-lock.sh
@@ -11,3 +11,5 @@ export VCS_REVISION
 export DATE
 export BASE_IMAGE="${OS_ALPINE}"
 export NETSNMP_VERSION="5.9.5.2-r0"
+
+export PLATFORMS="linux/amd64,linux/arm64"

--- a/onms-minion/version-lock.sh
+++ b/onms-minion/version-lock.sh
@@ -8,3 +8,5 @@ export VCS_SOURCE
 export VCS_REVISION
 export DATE
 export BASE_IMAGE="docker.io/opennms/minion:33.1.2"
+
+export PLATFORMS="linux/amd64,linux/arm64"

--- a/pleroma/version-lock.sh
+++ b/pleroma/version-lock.sh
@@ -12,3 +12,5 @@ export DATE
 export BASE_IMAGE_BUILD="${LANG_ELIXIR}"
 export BASE_IMAGE="alpine:3.21.3"
 export PLEROMA_VERSION="v2.9.1"
+
+export PLATFORMS="linux/amd64,linux/arm64"

--- a/retro-aim-server/Dockerfile.tpl
+++ b/retro-aim-server/Dockerfile.tpl
@@ -4,9 +4,18 @@
 # hadolint ignore=DL3006
 FROM "${BASE_IMAGE}"
 
-ADD "https://github.com/mk6i/retro-aim-server/releases/download/v${RETRO_AIM_SERVER_VERSION}/retro_aim_server.${RETRO_AIM_SERVER_VERSION}.linux.x86_64.tar.gz" /tmp/retro-aim-server.tar.gz
-
-RUN tar xzf /tmp/retro-aim-server.tar.gz --strip-component=1 -C /usr/bin && \
+ARG TARGETARCH
+# Upstream names the amd64 asset "x86_64" and the arm64 one "arm64_arm7_raspberry_pi".
+# hadolint ignore=DL3018
+RUN case "$TARGETARCH" in \
+      amd64) A=x86_64 ;; \
+      arm64) A=arm64_arm7_raspberry_pi ;; \
+      *) echo "unsupported TARGETARCH=$TARGETARCH" >&2; exit 1 ;; \
+    esac && \
+    apk add --no-cache --virtual .fetch curl && \
+    curl -fsSLo /tmp/retro-aim-server.tar.gz "https://github.com/mk6i/retro-aim-server/releases/download/v${RETRO_AIM_SERVER_VERSION}/retro_aim_server.${RETRO_AIM_SERVER_VERSION}.linux.${A}.tar.gz" && \
+    apk del .fetch && \
+    tar xzf /tmp/retro-aim-server.tar.gz --strip-component=1 -C /usr/bin && \
     rm -rf /tmp/retro-aim-server.tar.gz && \
     adduser -S raims
 

--- a/retro-aim-server/version-lock.sh
+++ b/retro-aim-server/version-lock.sh
@@ -11,3 +11,5 @@ export VCS_REVISION
 export DATE
 export BASE_IMAGE="alpine:3.21.2"
 export RETRO_AIM_SERVER_VERSION="0.15.3"
+
+export PLATFORMS="linux/amd64,linux/arm64"

--- a/robotframework/version-lock.sh
+++ b/robotframework/version-lock.sh
@@ -14,3 +14,5 @@ export DATE
 # LANG_PYTHON_3_ALPINE 3.9 pin (still used by sunshine) with a newer interpreter here.
 export BASE_IMAGE="python:3.14.1-alpine3.21"
 export GIT_COMMIT="17d482f2cba1a8735df0a9278ae6e68c500537c1"
+
+export PLATFORMS="linux/amd64,linux/arm64"

--- a/shellcheck/version-lock.sh
+++ b/shellcheck/version-lock.sh
@@ -13,3 +13,5 @@ export BASE_IMAGE_BUILD="${OS_ALPINE}"
 export BASE_IMAGE="${OS_ALPINE}"
 export SHELLCHECK_VERSION="0.10.0-r1"
 export BASH_VERSION="5.2.26-r0"
+
+export PLATFORMS="linux/amd64,linux/arm64"

--- a/sunshine/version-lock.sh
+++ b/sunshine/version-lock.sh
@@ -11,3 +11,5 @@ export VCS_REVISION
 export DATE
 export BASE_IMAGE="${LANG_PYTHON_3_ALPINE}"
 export GIT_COMMIT="c84bd379574d8685e39460420537f52be692d103"
+
+export PLATFORMS="linux/amd64,linux/arm64"

--- a/udpgen/version-lock.sh
+++ b/udpgen/version-lock.sh
@@ -11,3 +11,5 @@ export VCS_REVISION
 export DATE
 export BASE_IMAGE="${OS_UBUNTU}"
 export GIT_COMMIT="500967216ddad627480b7d204411a3ec6b1ec4b0"
+
+export PLATFORMS="linux/amd64,linux/arm64"

--- a/vpp/version-lock.sh
+++ b/vpp/version-lock.sh
@@ -11,3 +11,5 @@ export VCS_REVISION
 export DATE
 export BASE_IMAGE="${OS_UBUNTU}"
 export VPP_VERSION="24.10-release"
+
+export PLATFORMS="linux/amd64,linux/arm64"

--- a/zebra/version-lock.sh
+++ b/zebra/version-lock.sh
@@ -11,3 +11,5 @@ export VCS_REVISION
 export DATE
 export BASE_IMAGE="${OS_ALPINE}"
 export QUAGGA_VERSION="1.2.4-r9"
+
+export PLATFORMS="linux/amd64,linux/arm64"


### PR DESCRIPTION
Publish images to quay.io/labmonkeys via a quay robot account (QUAY_USERNAME,
QUAY_PASSWORD, QUAY_LABMONKEYS_ORG), build the platforms each project declares,
and sign the pushed index with keyless cosign (GitHub OIDC).

- include.mk: MULTI_ARCH sourced from a per-project PLATFORMS var; new sign
  target; the Dockerfile target now passes envsubst an allowlist of only the
  vars version-lock.sh/base_images.sh export, so Docker build args like
  $TARGETARCH (and the image's own $PATH) survive rendering.
- version-lock.sh: declare PLATFORMS per project (21 dual-arch, 7 amd64-only:
  5 Java blocked on the amd64-only openjdk base, featmap/gobetween have no
  arm64 upstream binary).
- Dockerfiles: diag, frrouting, mail-lab, gobgp, gohugo, retro-aim-server
  select their release artifact from $TARGETARCH.
- build.yml: quay secrets, QEMU+buildx, cosign install, id-token: write,
  publish+sign on main.
- README: multi-arch + signature-verification docs.

Assisted-by: ClaudeCode:claude-opus-4-8
Signed-off-by: Ronny Trommer <ronny@no42.org>
