### PR TITLE
fix(build): use docker-container buildx driver for multi-platform builds

### DIFF
--- a/include.mk
+++ b/include.mk
@@ -90,11 +90,14 @@ hadolint: Dockerfile
 	@echo -e "\033[0;32mDONE\033[0m"
 
 builder-instance: info
-	@if ! docker context inspect "$(BUILDER_INSTANCE)"; then docker context create "$(BUILDER_INSTANCE)"; fi;
-	docker context use "$(BUILDER_INSTANCE)"
+	@# A docker-container driver is required for multi-platform builds; the
+	@# default docker driver only supports a single platform.
+	@docker buildx inspect "$(BUILDER_INSTANCE)" >/dev/null 2>&1 || \
+	  docker buildx create --name "$(BUILDER_INSTANCE)" --driver docker-container --bootstrap
+	docker buildx use "$(BUILDER_INSTANCE)"
 
 oci: Dockerfile builder-instance
-	docker buildx build -o type=docker --platform="$(SINGLE_ARCH)" --tag $(PROJECT_DIR):$(subst /,-,$(SINGLE_ARCH)) .
+	docker buildx build --load --platform="$(SINGLE_ARCH)" --tag $(PROJECT_DIR):$(subst /,-,$(SINGLE_ARCH)) .
 	@mkdir -p ./build
 	docker image save $(PROJECT_DIR) -o ./build/$(PROJECT_DIR)_$(subst /,-,$(SINGLE_ARCH)).oci
 	@echo "Artifact for architecture $(SINGLE_ARCH): ./build/$(PROJECT_DIR)_$(subst /,-,$(SINGLE_ARCH)).oci"


### PR DESCRIPTION
The publish path failed on main with "Multi-platform build is not supported
for the docker driver": builder-instance set up a docker *context* (docker
driver), which only builds a single platform, so multi-arch publish could
never work. Create a docker-container buildx builder instead (the driver
multi-platform + QEMU emulation needs), and switch 'oci' to --load so the
single-arch local image still lands in the daemon for 'docker image save'.

The single-arch publish + cosign signing already worked (activemq); this
unblocks the 17 dual-arch images.

Assisted-by: ClaudeCode:claude-opus-4-8
Signed-off-by: Ronny Trommer <ronny@no42.org>
