### PR TITLE
fix(vpp): add missing release.tag

### DIFF
--- a/vpp/release.tag
+++ b/vpp/release.tag
@@ -1,0 +1,1 @@
+vpp:24.10-release


### PR DESCRIPTION
vpp had no release.tag, so RELEASE_TAG rendered empty and publish produced
an invalid image reference (quay.io/<org>/.b238 -> 'invalid reference
format'). Only 'publish' reads release.tag, so this stayed latent until the
registry secrets were configured. Tag it vpp:24.10-release (matching
VPP_VERSION).

Assisted-by: ClaudeCode:claude-opus-4-8
Signed-off-by: Ronny Trommer <ronny@no42.org>
